### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
             VRO_VERSION="$(grep -r "release_version=" version.txt | awk -F= '{print $2}')".RELEASE
           fi
           echo "VRO version ${VRO_VERSION}"
-          echo "::set-output name=VRO_RELEASE_VERSION::${VRO_VERSION}"
+          echo "VRO_RELEASE_VERSION=${VRO_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Build VRO Plugin
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


