### PR TITLE
Plugin upgrade from java 8 to 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
 
       - name: Extract branch name
         shell: bash

--- a/o11nplugin-vro-core/pom.xml
+++ b/o11nplugin-vro-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>vro</artifactId>
 		<groupId>com.vmware.avi</groupId>
-		<version>30.2.7-POST1</version>
+		<version>30.2.7.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/o11nplugin-vro-core/pom.xml
+++ b/o11nplugin-vro-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>vro</artifactId>
 		<groupId>com.vmware.avi</groupId>
-		<version>30.2.7.1</version>
+		<version>30.2.7</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>com.vmware.avi.sdk</groupId>
 			<artifactId>avisdk</artifactId>
-			<version>${project.parent.version}</version>
+			<version>30.2.7.1</version>
 		</dependency>
 
 		<dependency>

--- a/o11nplugin-vro-package/pom.xml
+++ b/o11nplugin-vro-package/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>vro</artifactId>
         <groupId>com.vmware.avi</groupId>
-        <version>30.2.7-POST1</version>
+        <version>30.2.7.1</version>
     </parent>
 
     <properties>

--- a/o11nplugin-vro-package/pom.xml
+++ b/o11nplugin-vro-package/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>vro</artifactId>
         <groupId>com.vmware.avi</groupId>
-        <version>30.2.7.1</version>
+        <version>30.2.7</version>
     </parent>
 
     <properties>

--- a/o11nplugin-vro/pom.xml
+++ b/o11nplugin-vro/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<artifactId>vro</artifactId>
 		<groupId>com.vmware.avi</groupId>
-		<version>30.2.7.1</version>
+		<version>30.2.7</version>
 	</parent>
 
 	<dependencies>

--- a/o11nplugin-vro/pom.xml
+++ b/o11nplugin-vro/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<artifactId>vro</artifactId>
 		<groupId>com.vmware.avi</groupId>
-		<version>30.2.7-POST1</version>
+		<version>30.2.7.1</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.vmware.avi</groupId>
 	<artifactId>vro</artifactId>
 	<packaging>pom</packaging>
-	<version>30.2.7-POST1</version>
+	<version>30.2.7.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.vmware.avi</groupId>
 	<artifactId>vro</artifactId>
 	<packaging>pom</packaging>
-	<version>30.2.7.1</version>
+	<version>30.2.7</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
**Changes done**
 - GitHub Workflow : Updated `setup-java` to use Java 17.
 - Java Upgrade : Upgraded compiler source/target to 17 in build configuration.
 - Avi SDK Update : Bumped Avi SDK version to `3.2.7.1`.
 - Avi Plugin Update : Bumped Plugin version to `3.2.7`.

**Verification Done**
- Verified local build passes with JDK 17.