### PR TITLE
AV-276818 : Upgrade the vRO plugin from java 8 to java 17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Maven Central Repository
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 17
 
       - name: Extract branch name
         shell: bash
@@ -63,6 +63,7 @@ jobs:
       - name: Build VRO Plugin
         run: |
           echo "Build VRO Version ${{ steps.get_vro_version.outputs.VRO_RELEASE_VERSION }}"
+          export MAVEN_OPTS="--add-exports=java.base/sun.security.x509=ALL-UNNAMED"
           mvn versions:set -DnewVersion=${{ steps.get_vro_version.outputs.VRO_RELEASE_VERSION }}
           mvn clean install -Dmaven.wagon.http.ssl.insecure:true -Dmaven.wagon.http.ssl.allowall:true -Dbuild.number=50 -DskipTests
           ls o11nplugin-vro/target/

--- a/o11nplugin-vro-core/pom.xml
+++ b/o11nplugin-vro-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>vro</artifactId>
 		<groupId>com.vmware.avi</groupId>
-		<version>32.1.1-Post1</version>
+		<version>32.1.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
@@ -14,16 +14,11 @@
 	<packaging>jar</packaging>
 
 	<dependencies>
-		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>4.5.13</version>
-		</dependency>
-
+	
 		<dependency>
 			<groupId>com.vmware.avi.sdk</groupId>
 			<artifactId>avisdk</artifactId>
-			<version>${project.parent.version}</version>
+			<version>32.1.1.1</version>
 		</dependency>
 
 		<dependency>

--- a/o11nplugin-vro-package/pom.xml
+++ b/o11nplugin-vro-package/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <artifactId>vro</artifactId>
         <groupId>com.vmware.avi</groupId>
-        <version>32.1.1-Post1</version>
+        <version>32.1.1</version>
     </parent>
 
     <properties>

--- a/o11nplugin-vro/pom.xml
+++ b/o11nplugin-vro/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<artifactId>vro</artifactId>
 		<groupId>com.vmware.avi</groupId>
-		<version>32.1.1-Post1</version>
+		<version>32.1.1</version>
 	</parent>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>com.vmware.avi</groupId>
 	<artifactId>vro</artifactId>
 	<packaging>pom</packaging>
-	<version>32.1.1-Post1</version>
+	<version>32.1.1</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
**Changes done**
 - GitHub Workflow : Updated `setup-java` to use Java 17.
 - Java Upgrade : Upgraded compiler source/target to 17 in build configuration.
 - Avi SDK Update : Bumped Avi SDK version to `32.1.1.1`.
 - Avi Plugin Update : Bumped Plugin version to `32.1.1`.

**Verification Done**
- Verified local build passes with JDK 17.